### PR TITLE
Fix code scanning alert no. 1: Unvalidated dynamic method call

### DIFF
--- a/src/libs/language-provider/index.tsx
+++ b/src/libs/language-provider/index.tsx
@@ -56,10 +56,11 @@ export function LanguageProvider({ children }: LanguageProviderProps) {
   dayjs.locale(currentLang === 'zh' ? 'zh-cn' : currentLang);
 
   useEffect(() => {
-    if (!messages[currentLang])
+    if (!messages[currentLang] && messageLoader.hasOwnProperty(currentLang)) {
       messageLoader[currentLang]?.().then((messages) =>
         setMessages((cache: any) => ({ ...cache, [currentLang]: messages }))
       );
+    }
   }, [currentLang]);
 
   return (


### PR DESCRIPTION
Fixes [https://github.com/VersoriumX/Creative-Lab/security/code-scanning/1](https://github.com/VersoriumX/Creative-Lab/security/code-scanning/1)

To fix the problem, we need to ensure that the key used to access the `messageLoader` object is valid. We can achieve this by checking if the key exists in the `messageLoader` object before attempting to call the method. This can be done using the `hasOwnProperty` method or by converting `messageLoader` to a `Map` and using the `has` method.

The best way to fix the problem without changing existing functionality is to add a check using `hasOwnProperty` to validate the key before accessing the `messageLoader` object. This ensures that only valid keys are used, preventing potential runtime errors.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
